### PR TITLE
Fix DokuWiki 2025-05-14a compatibility issues

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -37,13 +37,9 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler) {
 
         $match = substr($match, 7, -2);
-        $parts = sexplode('|', $match, 2);
-        $base = $parts[0] ?? '';
-        $title = $parts[1] ?? '';
+        [$base, $title] = sexplode('|', $match, 2);
         
-        $parts = sexplode(' ', $base, 2);
-        $base = $parts[0] ?? '';
-        $refresh = $parts[1] ?? '';
+        [$base, $refresh] = sexplode(' ', $base, 2);
 
         if (preg_match('/(\d+)([dhm])/', $refresh, $match)) {
             $period = array('d' => 86400, 'h' => 3600, 'm' => 60);

--- a/syntax.php
+++ b/syntax.php
@@ -94,7 +94,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Handle remote directories
      */
-    private function _directory($url, &$renderer, $path, $refresh) {
+    protected function _directory($url, &$renderer, $path, $refresh) {
         global $conf, $INPUT;
 
         $cache = getCacheName($url.$path, '.repo');
@@ -117,7 +117,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Extract links and list them as directory contents
      */
-    private function _index($url, $path, $base = '', $lvl = 0) {
+    protected function _index($url, $path, $base = '', $lvl = 0) {
 
         // download the index html file
         $http = new DokuHTTPClient();
@@ -147,7 +147,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Handle remote images
      */
-    private function _image($url, &$renderer) {
+    protected function _image($url, &$renderer) {
         $renderer->p_open();
         $renderer->externalmedia($url, NULL, NULL, NULL, NULL, 'recache');
         $renderer->p_close();
@@ -156,7 +156,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Handle remote source code files: display as code box with link to file at the end
      */
-    private function _codefile($url, &$renderer, $refresh) {
+    protected function _codefile($url, &$renderer, $refresh) {
 
         // output the code box with syntax highlighting
         $renderer->doc .= $this->_cached_geshi($url, $refresh);
@@ -174,7 +174,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
      * @author Christopher Smith <chris@jalakai.co.uk>
      * @author Esther Brunner <wikidesign@gmail.com>
      */
-    private function _cached_geshi($url, $refresh) {
+    protected function _cached_geshi($url, $refresh) {
         global $conf, $INPUT;
 
         $cache = getCacheName($url, '.code');
@@ -217,7 +217,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Show where we are with link back to main repository
      */
-    private function _location($path, $title, &$renderer) {
+    protected function _location($path, $title, &$renderer) {
         global $ID;
 
         $renderer->p_open();

--- a/syntax.php
+++ b/syntax.php
@@ -224,7 +224,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
         $renderer->internallink($ID, $title);
 
         $base = '';
-        $dirs = sexplode('/', $path);
+        $dirs = explode('/', $path);
         $n = count($dirs);
         for ($i = 0; $i < $n-1; $i++) {
             $base .= hsc($dirs[$i]).'/';

--- a/syntax.php
+++ b/syntax.php
@@ -24,17 +24,17 @@ use dokuwiki\HTTP\DokuHTTPClient;
  * need to inherit from this class
  */
 class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
-    function getType() { return 'substition'; }
-    function getSort() { return 301; }
-    function getPType() { return 'block'; }
-    function connectTo($mode) {
+    public function getType() { return 'substition'; }
+    public function getSort() { return 301; }
+    public function getPType() { return 'block'; }
+    public function connectTo($mode) {
         $this->Lexer->addSpecialPattern("{{repo>.+?}}", $mode, 'plugin_repo');
     }
 
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
 
         $match = substr($match, 7, -2);
         [$base, $title] = sexplode('|', $match, 2);
@@ -56,7 +56,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, Doku_Renderer $renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         global $INPUT;
 
         // construct requested URL
@@ -94,7 +94,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Handle remote directories
      */
-    function _directory($url, &$renderer, $path, $refresh) {
+    private function _directory($url, &$renderer, $path, $refresh) {
         global $conf, $INPUT;
 
         $cache = getCacheName($url.$path, '.repo');
@@ -117,7 +117,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Extract links and list them as directory contents
      */
-    function _index($url, $path, $base = '', $lvl = 0) {
+    private function _index($url, $path, $base = '', $lvl = 0) {
 
         // download the index html file
         $http = new DokuHTTPClient();
@@ -147,7 +147,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Handle remote images
      */
-    function _image($url, &$renderer) {
+    private function _image($url, &$renderer) {
         $renderer->p_open();
         $renderer->externalmedia($url, NULL, NULL, NULL, NULL, 'recache');
         $renderer->p_close();
@@ -156,7 +156,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Handle remote source code files: display as code box with link to file at the end
      */
-    function _codefile($url, &$renderer, $refresh) {
+    private function _codefile($url, &$renderer, $refresh) {
 
         // output the code box with syntax highlighting
         $renderer->doc .= $this->_cached_geshi($url, $refresh);
@@ -174,7 +174,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
      * @author Christopher Smith <chris@jalakai.co.uk>
      * @author Esther Brunner <wikidesign@gmail.com>
      */
-    function _cached_geshi($url, $refresh) {
+    private function _cached_geshi($url, $refresh) {
         global $conf, $INPUT;
 
         $cache = getCacheName($url, '.code');
@@ -217,7 +217,7 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
     /**
      * Show where we are with link back to main repository
      */
-    function _location($path, $title, &$renderer) {
+    private function _location($path, $title, &$renderer) {
         global $ID;
 
         $renderer->p_open();


### PR DESCRIPTION
- Remove deprecated require_once() and fix undefined array keys
- Update DokuHTTPClient to namespaced class
- Fix undefined variables and unsafe array operations
- Improve GeSHi loading with fallback support